### PR TITLE
Updates for the Kotlin Builder Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ This plugin for IntelliJ IDEA provides a quick way to implement a (simplified) B
 - Generated `withoutX()` methods for nullable properties
 - Customizable builder class and method names via plugin configuration
 - Selectable placement of builder class in production or test sources
+- Automatic wrapping/unwrapping of "wrapped primitive"-type properties
 
 ### *Work in progress:*
 
 - *Generated methods to add items to collection properties*
-- *Automatic wrapping/unwrapping of "wrapped primitive"-type properties*
 - *Detection and usage of existing builders for property types*
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ This plugin for IntelliJ IDEA provides a quick way to implement a (simplified) B
 - Customizable builder class and method names via plugin configuration
 - Selectable placement of builder class in production or test sources
 - Automatic wrapping/unwrapping of "wrapped primitive"-type properties
+- Detection and usage of existing builders for property types
 
 ### *Work in progress:*
 
 - *Generated methods to add items to collection properties*
-- *Detection and usage of existing builders for property types*
 
 ## Setup
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.6.5'
-    id 'org.jetbrains.kotlin.jvm' version '1.4.21'
-    id 'org.openjfx.javafxplugin' version '0.0.9'
+    id 'org.jetbrains.intellij' version '1.3.0'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.20'
+    id 'org.openjfx.javafxplugin' version '0.0.10'
 }
 
 group 'de.maibornwolff.its'
-version '1.1.0'
+version '1.2.0'
 
 repositories {
     mavenCentral()
@@ -16,7 +16,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-compiler"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation("com.squareup:kotlinpoet:1.7.2")
+    implementation("com.squareup:kotlinpoet:1.10.2")
 
     testImplementation("junit:junit:4.13")
     testImplementation("org.assertj:assertj-core:3.11.1")
@@ -24,7 +24,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2020.3.2'
+    version = '2021.3.1'
     plugins = [ 'java', 'Kotlin' ]
 }
 compileKotlin {
@@ -34,7 +34,7 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 patchPluginXml {
-    changeNotes """ - Compatibility with IntelliJ IDEA 2021.1"""
+    changeNotes = """ - Compatibility with IntelliJ IDEA 2021.3"""
 }
 
 javafx {
@@ -43,7 +43,7 @@ javafx {
 
 tasks {
     patchPluginXml {
-        sinceBuild('203')
-        untilBuild('211.*')
+        sinceBuild = '203'
+        untilBuild = '213.*'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,11 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 patchPluginXml {
-    changeNotes = """ - Compatibility with IntelliJ IDEA 2021.3
-                      - Automatic wrapping/unwrapping of "wrapped primitive"-type properties
-                      - Detection and usage of existing builders for property types"""
+    changeNotes = """<ul>
+                       <li> Compatibility with IntelliJ IDEA 2021.3 </li>
+                       <li> Automatic wrapping/unwrapping of "wrapped primitive"-type properties </li>
+                       <li> Detection and usage of existing builders for property types </li>
+                     </ul>"""
 }
 
 javafx {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,9 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 patchPluginXml {
-    changeNotes = """ - Compatibility with IntelliJ IDEA 2021.3"""
+    changeNotes = """ - Compatibility with IntelliJ IDEA 2021.3
+                      - Automatic wrapping/unwrapping of "wrapped primitive"-type properties
+                      - Detection and usage of existing builders for property types"""
 }
 
 javafx {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/de/maibornwolff/its/buildergenerator/actions/GenerateBuilderAction.kt
+++ b/src/main/kotlin/de/maibornwolff/its/buildergenerator/actions/GenerateBuilderAction.kt
@@ -36,7 +36,7 @@ class GenerateBuilderAction: AnAction() {
 
     private fun generateBuilder(dataClass: KtClass, project: Project) {
         val currentConfig = AppSettingsState.getInstance().config
-        val builderSpec = BuilderGenerator(currentConfig).generateBuilderForDataClass(dataClass)
+        val builderSpec = BuilderGenerator(currentConfig).generateBuilderForDataClass(dataClass, project)
         val builderDirectory = SourceRootChoice.chooseTargetDirectory(dataClass, project)
         val builderFileName = "${builderSpec.name}.${KotlinFileType.EXTENSION}"
         val builderFileContents = builderSpec.toString()

--- a/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/BuilderGenerator.kt
+++ b/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/BuilderGenerator.kt
@@ -41,7 +41,7 @@ class BuilderGenerator(private val config: GeneratorConfig) {
                 PropertySpec.builder(property.name, property.type.typeName)
                         .addModifiers(KModifier.PRIVATE)
                         .mutable()
-                        .initializer(CodeBlock.of(property.getDefaultValue(project, config)))
+                        .initializer(property.getDefaultValue(project, config))
                         .build()
             })
 

--- a/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Property.kt
+++ b/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Property.kt
@@ -19,13 +19,14 @@ data class Property(val name: String,
 
     companion object {
 
-        // TODO add defaults for Double, Float
         private val collectionsDefaultValuesMap = mapOf("List" to "emptyList()",
                                                         "Map" to "emptyMap()",
                                                         "Set" to "emptySet()",
                                                         "Array" to "emptyArray()")
 
         val primitiveDefaultValuesMap = mapOf("String" to "\"a·string\"",
+                                              "Float" to "1.0F",
+                                              "Double" to "1.0",
                                               "Int" to "42",
                                               "Boolean" to "false",
                                               "Long" to "23L")

--- a/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Property.kt
+++ b/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Property.kt
@@ -6,13 +6,13 @@ data class Property(val name: String,
                     val type: Type) {
 
     val defaultValue: String = when {
-        type.isNullable         -> "null"
-        type.isWrappedPrimitive -> generateWrappedPrimitiveDefault()
-        else                    -> defaultValuesMap[type.simpleName] ?: "TODO(\"Needs·a·default·value!\")"
+        type.isNullable                   -> "null"
+        type.wrappedPrimitiveType != null -> generateWrappedPrimitiveDefault(type.wrappedPrimitiveType)
+        else                              -> defaultValuesMap[type.simpleName] ?: "TODO(\"Needs·a·default·value!\")"
     }
 
-    private fun generateWrappedPrimitiveDefault(): String {
-        val wrappedTypeName = type.wrappedPrimitiveType
+    private fun generateWrappedPrimitiveDefault(wrappedType: WrappedPrimitive): String {
+        val wrappedTypeName = wrappedType.simpleName
         val wrappingTypeName = type.simpleName
         return "$wrappingTypeName(${defaultValuesMap[wrappedTypeName]})"
     }

--- a/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Property.kt
+++ b/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Property.kt
@@ -5,21 +5,32 @@ import org.jetbrains.kotlin.descriptors.ParameterDescriptor
 data class Property(val name: String,
                     val type: Type) {
 
-    val defaultValue = when {
-        type.isNullable -> "null"
-        else            -> defaultValuesMap[type.simpleName] ?: "TODO(\"Needs·a·default·value!\")"
+    val defaultValue: String = when {
+        type.isNullable         -> "null"
+        type.isWrappedPrimitive -> generateWrappedPrimitiveDefault()
+        else                    -> defaultValuesMap[type.simpleName] ?: "TODO(\"Needs·a·default·value!\")"
+    }
+
+    private fun generateWrappedPrimitiveDefault(): String {
+        val wrappedTypeName = type.wrappedPrimitiveType
+        val wrappingTypeName = type.simpleName
+        return "$wrappingTypeName(${defaultValuesMap[wrappedTypeName]})"
     }
 
     companion object {
 
-        val defaultValuesMap = mapOf("String" to "\"a·string\"",
-                                     "Int" to "42",
-                                     "Boolean" to "false",
-                                     "Long" to "23L",
-                                     "List" to "emptyList()",
-                                     "Map" to "emptyMap()",
-                                     "Set" to "emptySet()",
-                                     "Array" to "emptyArray()")
+        // TODO add defaults for Double, Float
+        private val collectionsDefaultValuesMap = mapOf("List" to "emptyList()",
+                                                        "Map" to "emptyMap()",
+                                                        "Set" to "emptySet()",
+                                                        "Array" to "emptyArray()")
+
+        val primitiveDefaultValuesMap = mapOf("String" to "\"a·string\"",
+                                              "Int" to "42",
+                                              "Boolean" to "false",
+                                              "Long" to "23L")
+
+        val defaultValuesMap = primitiveDefaultValuesMap + collectionsDefaultValuesMap
 
         fun fromParameterDescriptor(param: ParameterDescriptor) =
                 Property(name = param.name.asString(),

--- a/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Type.kt
+++ b/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Type.kt
@@ -4,18 +4,13 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
 import org.jetbrains.kotlin.idea.refactoring.fqName.fqName
-import org.jetbrains.kotlin.js.descriptorUtils.nameIfStandardType
-import org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope
 import org.jetbrains.kotlin.types.KotlinType
 
 data class Type(val simpleName: String,
                 val packageName: String,
                 val isNullable: Boolean,
-                val wrappedPrimitiveType: String?,
+                val wrappedPrimitiveType: WrappedPrimitive?,
                 val typeArguments: List<Type>) {
-
-    val isWrappedPrimitive: Boolean
-        get() = wrappedPrimitiveType != null
 
     companion object {
 
@@ -27,21 +22,8 @@ data class Type(val simpleName: String,
             return Type(simpleName = simpleName,
                         packageName = packageName,
                         isNullable = type.isMarkedNullable,
-                        wrappedPrimitiveType = wrappedPrimitiveTypeName(type),
+                        wrappedPrimitiveType = WrappedPrimitive.fromKotlinType(type),
                         typeArguments = type.arguments.map { fromKotlinType(it.type) })
-        }
-
-        // TODO provide with... functions for wrapped primitives using the primitive type as argument
-        private fun wrappedPrimitiveTypeName(type: KotlinType): String? {
-            val typeMemberScope = type.memberScope
-            return if (typeMemberScope is LazyClassMemberScope) {
-                val singleConstructor = typeMemberScope.getConstructors().singleOrNull()
-                val singleParameter = singleConstructor?.valueParameters?.singleOrNull()
-                val typeNameOfSingleParameter = singleParameter?.type?.nameIfStandardType?.toString()
-                typeNameOfSingleParameter?.takeIf { Property.primitiveDefaultValuesMap.containsKey(it) }
-            } else {
-                null
-            }
         }
     }
 

--- a/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Type.kt
+++ b/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Type.kt
@@ -31,7 +31,7 @@ data class Type(val simpleName: String,
                         typeArguments = type.arguments.map { fromKotlinType(it.type) })
         }
 
-        // TODO was passiert bei wrapped nullable primitive ?
+        // TODO provide with... functions for wrapped primitives using the primitive type as argument
         private fun wrappedPrimitiveTypeName(type: KotlinType): String? {
             val typeMemberScope = type.memberScope
             return if (typeMemberScope is LazyClassMemberScope) {

--- a/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Type.kt
+++ b/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/Type.kt
@@ -4,12 +4,18 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeName
 import org.jetbrains.kotlin.idea.refactoring.fqName.fqName
+import org.jetbrains.kotlin.js.descriptorUtils.nameIfStandardType
+import org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope
 import org.jetbrains.kotlin.types.KotlinType
 
 data class Type(val simpleName: String,
                 val packageName: String,
                 val isNullable: Boolean,
+                val wrappedPrimitiveType: String?,
                 val typeArguments: List<Type>) {
+
+    val isWrappedPrimitive: Boolean
+        get() = wrappedPrimitiveType != null
 
     companion object {
 
@@ -21,7 +27,21 @@ data class Type(val simpleName: String,
             return Type(simpleName = simpleName,
                         packageName = packageName,
                         isNullable = type.isMarkedNullable,
+                        wrappedPrimitiveType = wrappedPrimitiveTypeName(type),
                         typeArguments = type.arguments.map { fromKotlinType(it.type) })
+        }
+
+        // TODO was passiert bei wrapped nullable primitive ?
+        private fun wrappedPrimitiveTypeName(type: KotlinType): String? {
+            val typeMemberScope = type.memberScope
+            return if (typeMemberScope is LazyClassMemberScope) {
+                val singleConstructor = typeMemberScope.getConstructors().singleOrNull()
+                val singleParameter = singleConstructor?.valueParameters?.singleOrNull()
+                val typeNameOfSingleParameter = singleParameter?.type?.nameIfStandardType?.toString()
+                typeNameOfSingleParameter?.takeIf { Property.primitiveDefaultValuesMap.containsKey(it) }
+            } else {
+                null
+            }
         }
     }
 

--- a/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/WrappedPrimitive.kt
+++ b/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/WrappedPrimitive.kt
@@ -1,0 +1,34 @@
+package de.maibornwolff.its.buildergenerator.generator
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.TypeName
+import org.jetbrains.kotlin.idea.refactoring.fqName.fqName
+import org.jetbrains.kotlin.js.descriptorUtils.nameIfStandardType
+import org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope
+import org.jetbrains.kotlin.types.KotlinType
+
+data class WrappedPrimitive(val packageName: String,
+                            val simpleName: String) {
+
+    companion object {
+
+        fun fromKotlinType(type: KotlinType): WrappedPrimitive? {
+            val typeMemberScope = type.memberScope
+            return if (typeMemberScope is LazyClassMemberScope) {
+                val singleConstructor = typeMemberScope.getConstructors().singleOrNull()
+                val singleParameter = singleConstructor?.valueParameters?.singleOrNull()
+                val typeNameOfSingleParameter = singleParameter?.type?.nameIfStandardType?.toString()
+                val packageName = singleParameter?.type?.fqName?.parent().toString()
+                val wrappedPrimitiveTypeName =
+                        typeNameOfSingleParameter?.takeIf { Property.primitiveDefaultValuesMap.containsKey(it) }
+                wrappedPrimitiveTypeName?.let { WrappedPrimitive(packageName, it) }
+            } else {
+                null
+            }
+        }
+    }
+
+    val typeName: TypeName =
+            ClassName(packageName, simpleName)
+                    .copy(nullable = false) // TODO
+}

--- a/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/WrappedPrimitive.kt
+++ b/src/main/kotlin/de/maibornwolff/its/buildergenerator/generator/WrappedPrimitive.kt
@@ -8,7 +8,8 @@ import org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassMemberScope
 import org.jetbrains.kotlin.types.KotlinType
 
 data class WrappedPrimitive(val packageName: String,
-                            val simpleName: String) {
+                            val simpleName: String,
+                            val isNullable: Boolean) {
 
     companion object {
 
@@ -16,19 +17,26 @@ data class WrappedPrimitive(val packageName: String,
             val typeMemberScope = type.memberScope
             return if (typeMemberScope is LazyClassMemberScope) {
                 val singleConstructor = typeMemberScope.getConstructors().singleOrNull()
-                val singleParameter = singleConstructor?.valueParameters?.singleOrNull()
-                val typeNameOfSingleParameter = singleParameter?.type?.nameIfStandardType?.toString()
-                val packageName = singleParameter?.type?.fqName?.parent().toString()
-                val wrappedPrimitiveTypeName =
-                        typeNameOfSingleParameter?.takeIf { Property.primitiveDefaultValuesMap.containsKey(it) }
-                wrappedPrimitiveTypeName?.let { WrappedPrimitive(packageName, it) }
+                val singleParameterType = singleConstructor?.valueParameters?.singleOrNull()?.type
+                createWrappedPrimitiveFromSingleConstructorParameter(singleParameterType)
             } else {
                 null
             }
+        }
+
+        private fun createWrappedPrimitiveFromSingleConstructorParameter(singleParameterType: KotlinType?): WrappedPrimitive? {
+            val typeNameOfSingleParameter = singleParameterType?.nameIfStandardType?.toString()
+            val packageName = singleParameterType?.fqName?.parent().toString()
+            val wrappedPrimitiveTypeName =
+                    typeNameOfSingleParameter?.takeIf { Property.primitiveDefaultValuesMap.containsKey(it) }
+            val nullablePrimitive = singleParameterType?.isMarkedNullable
+            return if (nullablePrimitive != null && wrappedPrimitiveTypeName != null) {
+                WrappedPrimitive(packageName, wrappedPrimitiveTypeName, nullablePrimitive)
+            } else null
         }
     }
 
     val typeName: TypeName =
             ClassName(packageName, simpleName)
-                    .copy(nullable = false) // TODO
+                    .copy(nullable = isNullable)
 }

--- a/src/test/kotlin/de/maibornwolff/its/buildergenerator/actions/BuilderGenerationTest.kt
+++ b/src/test/kotlin/de/maibornwolff/its/buildergenerator/actions/BuilderGenerationTest.kt
@@ -19,4 +19,11 @@ class BuilderGenerationTest: GenerateBuilderActionLightTestBase() {
 
         testBuilderGeneratedCorrectlyForDataClass("DataClassWithComplexTypes", 30)
     }
+
+    @Test
+    fun testGenerateBuilderForSimpleDataWithWrappedPrimitivesClass() {
+        TestDialogManager.setTestDialog(TestDialog.OK)
+
+        testBuilderGeneratedCorrectlyForDataClass("SimpleDataClassWithWrappedPrimitives", 30)
+    }
 }

--- a/src/test/kotlin/de/maibornwolff/its/buildergenerator/actions/BuilderGenerationTest.kt
+++ b/src/test/kotlin/de/maibornwolff/its/buildergenerator/actions/BuilderGenerationTest.kt
@@ -26,4 +26,13 @@ class BuilderGenerationTest: GenerateBuilderActionLightTestBase() {
 
         testBuilderGeneratedCorrectlyForDataClass("SimpleDataClassWithWrappedPrimitives", 30)
     }
+
+    @Test
+    fun testGenerateBuilderForComplexDataClassWithBuilderDetectionForDefaults() {
+        TestDialogManager.setTestDialog(TestDialog.OK)
+
+        testBuilderGeneratedCorrectlyForDataClassWithOtherBuilder(dataClassUnderTest = "DataClassWithComplexTypeWithBuilder",
+                                                                  otherBuilder = "PropertyTypeWithBuilderBuilder.kt",
+                                                                  caretOffsetOnDataClassName = 30)
+    }
 }

--- a/src/test/kotlin/de/maibornwolff/its/buildergenerator/actions/BuilderGenerationTest.kt
+++ b/src/test/kotlin/de/maibornwolff/its/buildergenerator/actions/BuilderGenerationTest.kt
@@ -32,7 +32,7 @@ class BuilderGenerationTest: GenerateBuilderActionLightTestBase() {
         TestDialogManager.setTestDialog(TestDialog.OK)
 
         testBuilderGeneratedCorrectlyForDataClassWithOtherBuilder(dataClassUnderTest = "DataClassWithComplexTypeWithBuilder",
-                                                                  otherBuilder = "PropertyTypeWithBuilderBuilder.kt",
+                                                                  otherBuilder = "otherpackage/PropertyTypeWithBuilderBuilder.kt",
                                                                   caretOffsetOnDataClassName = 30)
     }
 }

--- a/src/test/kotlin/de/maibornwolff/its/buildergenerator/actions/GenerateBuilderActionLightTestBase.kt
+++ b/src/test/kotlin/de/maibornwolff/its/buildergenerator/actions/GenerateBuilderActionLightTestBase.kt
@@ -47,4 +47,27 @@ abstract class GenerateBuilderActionLightTestBase: BasePlatformTestCase() {
         assertThat(generatedBuilderCode).isEqualToIgnoringWhitespace(expectedBuilderCode)
     }
 
+    protected fun testBuilderGeneratedCorrectlyForDataClassWithOtherBuilder(dataClassUnderTest: String,
+                                                                            otherBuilder: String,
+                                                                            caretOffsetOnDataClassName: Int,
+                                                                            builderSuffix: String = "Builder") {
+        // arrange
+        val inputFile = "$dataClassUnderTest.kt"
+        myFixture.configureByFile(inputFile)
+        myFixture.copyFileToProject("$testDataPath/$otherBuilder")
+
+        // act
+        myFixture.editor.moveCaret(caretOffsetOnDataClassName)
+        myFixture.testAction(GenerateBuilderAction())
+
+        // assert
+        val generatedBuilderFile =
+                myFixture.file.containingDirectory.files.singleOrNull { it.name == "$dataClassUnderTest$builderSuffix.kt" }
+        assertThat(generatedBuilderFile).isNotNull
+
+        val generatedBuilderCode = VfsUtil.loadText(generatedBuilderFile!!.virtualFile)
+        val expectedBuilderCode = File("$testDataPath/expected/$dataClassUnderTest$builderSuffix.kt").readText()
+        assertThat(generatedBuilderCode).isEqualToIgnoringWhitespace(expectedBuilderCode)
+    }
+
 }

--- a/src/test/resources/testdata/DataClassWithComplexTypeWithBuilder.kt
+++ b/src/test/resources/testdata/DataClassWithComplexTypeWithBuilder.kt
@@ -1,0 +1,5 @@
+package testdata
+
+data class DataClassWithComplexTypeWithBuilder(val property1: PropertyTypeWithBuilder)
+
+data class PropertyTypeWithBuilder(val rawValueInt: Int, val rawValueBoolean: Boolean)

--- a/src/test/resources/testdata/DataClassWithComplexTypes.kt
+++ b/src/test/resources/testdata/DataClassWithComplexTypes.kt
@@ -6,6 +6,6 @@ data class DataClassWithComplexTypes(val property1: PropertyType1,
                                      val mapOfComplexTypeProperty: Map<Int, PropertyType2>,
                                      val nullableProperty: String?)
 
-data class PropertyType1(val rawValue: Int)
+data class PropertyType1(val rawValue: Int, val anotherRawValue: Int)
 
 data class PropertyType2(val rawValue: String, val otherValue: Boolean)

--- a/src/test/resources/testdata/PropertyTypeWithBuilderBuilder.kt
+++ b/src/test/resources/testdata/PropertyTypeWithBuilderBuilder.kt
@@ -1,0 +1,12 @@
+package testdata
+
+import kotlin.Boolean
+import kotlin.Int
+
+public class PropertyTypeWithBuilderBuilder {
+
+    private var rawValueInt: Int = 42
+    private var rawValueBoolean: Boolean = false
+
+    public fun build() = PropertyTypeWithBuilder(rawValueInt, rawValueBoolean)
+}

--- a/src/test/resources/testdata/SimpleDataClass.kt
+++ b/src/test/resources/testdata/SimpleDataClass.kt
@@ -2,4 +2,6 @@ package testdata
 
 data class SimpleDataClass(val intProperty: Int,
                            val stringProperty: String,
-                           val booleanProperty: Boolean)
+                           val booleanProperty: Boolean,
+                           val doubleProperty: Double,
+                           val floatProperty: Float)

--- a/src/test/resources/testdata/SimpleDataClassWithWrappedPrimitives.kt
+++ b/src/test/resources/testdata/SimpleDataClassWithWrappedPrimitives.kt
@@ -1,0 +1,11 @@
+package testdata
+
+data class SimpleDataClassWithWrappedPrimitives(val intProperty: WrappedInt,
+                                                val stringProperty: WrappedString,
+                                                val booleanProperty: WrappedBoolean)
+
+data class WrappedInt(val rawValue: Int)
+
+data class WrappedString(val rawValue: String)
+
+data class WrappedBoolean(val rawValue: Boolean)

--- a/src/test/resources/testdata/SimpleDataClassWithWrappedPrimitives.kt
+++ b/src/test/resources/testdata/SimpleDataClassWithWrappedPrimitives.kt
@@ -4,7 +4,7 @@ data class SimpleDataClassWithWrappedPrimitives(val intProperty: WrappedInt,
                                                 val stringProperty: WrappedString,
                                                 val booleanProperty: WrappedBoolean)
 
-data class WrappedInt(val rawValue: Int)
+data class WrappedInt(val rawValue: Int?)
 
 data class WrappedString(val rawValue: String)
 

--- a/src/test/resources/testdata/expected/DataClassWithComplexTypeWithBuilderBuilder.kt
+++ b/src/test/resources/testdata/expected/DataClassWithComplexTypeWithBuilderBuilder.kt
@@ -1,5 +1,6 @@
 package testdata
 
+import testdata.otherpackage.PropertyTypeWithBuilderBuilder
 
 public class DataClassWithComplexTypeWithBuilderBuilder {
 

--- a/src/test/resources/testdata/expected/DataClassWithComplexTypeWithBuilderBuilder.kt
+++ b/src/test/resources/testdata/expected/DataClassWithComplexTypeWithBuilderBuilder.kt
@@ -1,0 +1,14 @@
+package testdata
+
+
+public class DataClassWithComplexTypeWithBuilderBuilder {
+
+    private var property1: PropertyTypeWithBuilder = PropertyTypeWithBuilderBuilder().build()
+
+    public fun build() = DataClassWithComplexTypeWithBuilder(property1 = property1)
+
+    public fun withProperty1(property1: PropertyTypeWithBuilder) = apply {
+        this.property1 = property1
+    }
+
+}

--- a/src/test/resources/testdata/expected/SimpleDataClassBuilder.kt
+++ b/src/test/resources/testdata/expected/SimpleDataClassBuilder.kt
@@ -1,25 +1,44 @@
 package testdata
 
 import kotlin.Boolean
+import kotlin.Double
+import kotlin.Float
 import kotlin.Int
 import kotlin.String
 
 public class SimpleDataClassBuilder {
+
     private var intProperty: Int = 42
 
     private var stringProperty: String = "a string"
 
     private var booleanProperty: Boolean = false
 
+    private var doubleProperty: Double = 1.0
+
+    private var floatProperty: Float = 1.0F
+
     public fun build() = SimpleDataClass(intProperty = intProperty,
                                          stringProperty = stringProperty,
-                                         booleanProperty = booleanProperty)
+                                         booleanProperty = booleanProperty,
+                                         doubleProperty = doubleProperty,
+                                         floatProperty = floatProperty)
 
     public fun withIntProperty(intProperty: Int) = apply { this.intProperty = intProperty }
 
-    public fun withStringProperty(stringProperty: String) = apply { this.stringProperty =
-        stringProperty }
+    public fun withStringProperty(stringProperty: String) = apply {
+        this.stringProperty = stringProperty
+    }
 
-    public fun withBooleanProperty(booleanProperty: Boolean) = apply { this.booleanProperty =
-        booleanProperty }
+    public fun withBooleanProperty(booleanProperty: Boolean) = apply {
+        this.booleanProperty = booleanProperty
+    }
+
+    public fun withDoubleProperty(doubleProperty: Double) = apply {
+        this.doubleProperty = doubleProperty
+    }
+
+    public fun withFloatProperty(floatProperty: Float) = apply {
+        this.floatProperty = floatProperty
+    }
 }

--- a/src/test/resources/testdata/expected/SimpleDataClassWithWrappedPrimitivesBuilder.kt
+++ b/src/test/resources/testdata/expected/SimpleDataClassWithWrappedPrimitivesBuilder.kt
@@ -1,0 +1,21 @@
+package testdata
+
+public class SimpleDataClassWithWrappedPrimitivesBuilder {
+    private var intProperty: WrappedInt = WrappedInt(42)
+
+    private var stringProperty: WrappedString = WrappedString("a string")
+
+    private var booleanProperty: WrappedBoolean = WrappedBoolean(false)
+
+    public fun build() = SimpleDataClassWithWrappedPrimitives(intProperty = intProperty,
+                                                              stringProperty = stringProperty,
+                                                              booleanProperty = booleanProperty)
+
+    public fun withIntProperty(intProperty: WrappedInt) = apply { this.intProperty = intProperty }
+
+    public fun withStringProperty(stringProperty: WrappedString) = apply { this.stringProperty =
+        stringProperty }
+
+    public fun withBooleanProperty(booleanProperty: WrappedBoolean) = apply { this.booleanProperty =
+        booleanProperty }
+}

--- a/src/test/resources/testdata/expected/SimpleDataClassWithWrappedPrimitivesBuilder.kt
+++ b/src/test/resources/testdata/expected/SimpleDataClassWithWrappedPrimitivesBuilder.kt
@@ -17,7 +17,7 @@ public class SimpleDataClassWithWrappedPrimitivesBuilder {
 
     public fun withIntProperty(intProperty: WrappedInt) = apply { this.intProperty = intProperty }
 
-    public fun withIntProperty(intProperty: Int) = apply { this.intProperty = WrappedInt(intProperty) }
+    public fun withIntProperty(intProperty: Int?) = apply { this.intProperty = WrappedInt(intProperty) }
 
     public fun withStringProperty(stringProperty: WrappedString) = apply { this.stringProperty = stringProperty }
 

--- a/src/test/resources/testdata/expected/SimpleDataClassWithWrappedPrimitivesBuilder.kt
+++ b/src/test/resources/testdata/expected/SimpleDataClassWithWrappedPrimitivesBuilder.kt
@@ -1,5 +1,9 @@
 package testdata
 
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+
 public class SimpleDataClassWithWrappedPrimitivesBuilder {
     private var intProperty: WrappedInt = WrappedInt(42)
 
@@ -13,9 +17,16 @@ public class SimpleDataClassWithWrappedPrimitivesBuilder {
 
     public fun withIntProperty(intProperty: WrappedInt) = apply { this.intProperty = intProperty }
 
-    public fun withStringProperty(stringProperty: WrappedString) = apply { this.stringProperty =
-        stringProperty }
+    public fun withIntProperty(intProperty: Int) = apply { this.intProperty = WrappedInt(intProperty) }
 
-    public fun withBooleanProperty(booleanProperty: WrappedBoolean) = apply { this.booleanProperty =
-        booleanProperty }
+    public fun withStringProperty(stringProperty: WrappedString) = apply { this.stringProperty = stringProperty }
+
+    public fun withStringProperty(stringProperty: String) =
+            apply { this.stringProperty = WrappedString(stringProperty) }
+
+    public fun withBooleanProperty(booleanProperty: WrappedBoolean) =
+            apply { this.booleanProperty = booleanProperty }
+
+    public fun withBooleanProperty(booleanProperty: Boolean) =
+            apply { this.booleanProperty = WrappedBoolean(booleanProperty) }
 }

--- a/src/test/resources/testdata/otherpackage/PropertyTypeWithBuilderBuilder.kt
+++ b/src/test/resources/testdata/otherpackage/PropertyTypeWithBuilderBuilder.kt
@@ -1,5 +1,6 @@
-package testdata
+package testdata.otherpackage
 
+import testdata.PropertyTypeWithBuilder
 import kotlin.Boolean
 import kotlin.Int
 


### PR DESCRIPTION
- Automatic wrapping/unwrapping of "wrapped primitive"-type properties
- Detection and usage of existing builders for property types
- - works for intellij 2021.1.3